### PR TITLE
skip first slide if it's not showable

### DIFF
--- a/packages/example/src/components/pages/SliderFormWithSkips.js
+++ b/packages/example/src/components/pages/SliderFormWithSkips.js
@@ -1,0 +1,72 @@
+/* eslint-disable no-alert, react/prefer-stateless-function */
+import React, { Component } from 'react';
+import { Field } from '@swan-form/field';
+import { Slide, Slider } from '@swan-form/slider';
+import { hot } from 'react-hot-loader';
+
+const isNull = value => value === null;
+const isDefined = value => typeof value !== 'undefined';
+
+/**
+ * Helper validation
+ */
+const required = value => (isDefined(value) && !isNull(value) && value.trim() ? false : 'Required');
+
+const onSubmit = values => {
+  alert(JSON.stringify(values));
+  return values;
+};
+const beforeSubmit = values =>
+  Promise.resolve(
+    Object.keys(values).reduce(
+      (acc, key) => ({ ...acc, [key]: typeof values[key] === 'string' ? values[key].toUpperCase() : values[key] }),
+      {},
+    ),
+  );
+
+class SliderFormWithSkips extends Component {
+  scrollToTop = () => {
+    if (this.wrapper) {
+      // will probably only work fully in Firefox and Chrome
+      this.wrapper.scrollIntoView({ behavior: 'smooth', block: 'start', inline: 'nearest' });
+    }
+  };
+
+  setRef = el => {
+    this.wrapper = el;
+  };
+
+  render() {
+    return (
+      <div ref={this.setRef}>
+        <Slider afterSlideChange={this.scrollToTop} beforeSubmit={beforeSubmit} onSubmit={onSubmit}>
+          <Slide shouldShowIf={() => false}>
+            <div>
+              <h1>This should be skipped</h1>
+              <p>No one will ever read this text.</p>
+            </div>
+          </Slide>
+          <Slide>
+            <div>
+              <h1>Type &quot;skip&quot; to skip the next slide</h1>
+              <Field name="chooseSkip" placeholder='Type "skip" to skip' size={50} type="text" validate={required} />
+              <p>This is just another random question.</p>
+            </div>
+          </Slide>
+          <Slide shouldShowIf={values => values.chooseSkip !== 'skip'}>
+            <div>
+              <h2>Thanks for not skipping me. I feel so loved.</h2>
+            </div>
+          </Slide>
+          <Slide>
+            <div>
+              <h2>Well that&apos;s it I guess.</h2>
+            </div>
+          </Slide>
+        </Slider>
+      </div>
+    );
+  }
+}
+
+export default hot(module)(SliderFormWithSkips);

--- a/packages/example/src/components/pages/SliderFormWithoutShowableSlides.js
+++ b/packages/example/src/components/pages/SliderFormWithoutShowableSlides.js
@@ -1,0 +1,55 @@
+/* eslint-disable no-alert, react/prefer-stateless-function */
+import React, { Component } from 'react';
+import { Field } from '@swan-form/field';
+import { Slide, Slider } from '@swan-form/slider';
+import { hot } from 'react-hot-loader';
+
+const isNull = value => value === null;
+const isDefined = value => typeof value !== 'undefined';
+
+/**
+ * Helper validation
+ */
+const required = value => (isDefined(value) && !isNull(value) && value.trim() ? false : 'Required');
+
+const onSubmit = values => {
+  alert(JSON.stringify(values));
+  return values;
+};
+const beforeSubmit = values =>
+  Promise.resolve(
+    Object.keys(values).reduce(
+      (acc, key) => ({ ...acc, [key]: typeof values[key] === 'string' ? values[key].toUpperCase() : values[key] }),
+      {},
+    ),
+  );
+
+class SliderFormWithoutShowableSlides extends Component {
+  scrollToTop = () => {
+    if (this.wrapper) {
+      // will probably only work fully in Firefox and Chrome
+      this.wrapper.scrollIntoView({ behavior: 'smooth', block: 'start', inline: 'nearest' });
+    }
+  };
+
+  setRef = el => {
+    this.wrapper = el;
+  };
+
+  render() {
+    return (
+      <div ref={this.setRef}>
+        <Slider afterSlideChange={this.scrollToTop} beforeSubmit={beforeSubmit} onSubmit={onSubmit}>
+          <Slide shouldShowIf={() => false}>
+            <div>
+              <h1>This should be skipped</h1>
+              <p>No one will ever read this text.</p>
+            </div>
+          </Slide>
+        </Slider>
+      </div>
+    );
+  }
+}
+
+export default hot(module)(SliderFormWithoutShowableSlides);

--- a/packages/example/src/routes.js
+++ b/packages/example/src/routes.js
@@ -16,6 +16,11 @@ const Container = Loader(() => import(/* webpackChunkName: "container" */ './com
 
 const SliderForm = Loader(() => import(/* webpackChunkName: "sliderForm" */ './components/pages/SliderForm'), Loading);
 
+const SliderFormWithSkips = Loader(
+  () => import(/* webpackChunkName: "sliderFormWithSkips" */ './components/pages/SliderFormWithSkips'),
+  Loading,
+);
+
 const Formatters = Loader(
   () => import(/* webpackChunkName: "formatters-example" */ './components/pages/Formatters'),
   Loading,
@@ -68,6 +73,7 @@ export const pages = [
   ['/formatters', 'Formatters', Formatters],
   ['/regular', 'Regular Form', RegularForm],
   ['/slider-form', 'Slider', SliderForm],
+  ['/slider-form-with-skips', 'SliderWithSkips', SliderFormWithSkips],
   ['/styling', 'Styling', Styling],
   ['/nested', 'Nested', Nested],
   ['/with-redux', 'With Redux', Dummy],

--- a/packages/example/src/routes.js
+++ b/packages/example/src/routes.js
@@ -21,6 +21,14 @@ const SliderFormWithSkips = Loader(
   Loading,
 );
 
+const SliderFormWithoutShowableSlides = Loader(
+  () =>
+    import(
+      /* webpackChunkName: "sliderFormWithoutShowableSlides" */ './components/pages/SliderFormWithoutShowableSlides'
+    ),
+  Loading,
+);
+
 const Formatters = Loader(
   () => import(/* webpackChunkName: "formatters-example" */ './components/pages/Formatters'),
   Loading,
@@ -74,6 +82,7 @@ export const pages = [
   ['/regular', 'Regular Form', RegularForm],
   ['/slider-form', 'Slider', SliderForm],
   ['/slider-form-with-skips', 'SliderWithSkips', SliderFormWithSkips],
+  ['/slider-form-without-showable-slides', 'SliderWithoutShowableSlides', SliderFormWithoutShowableSlides],
   ['/styling', 'Styling', Styling],
   ['/nested', 'Nested', Nested],
   ['/with-redux', 'With Redux', Dummy],

--- a/packages/slider/src/Slider.tsx
+++ b/packages/slider/src/Slider.tsx
@@ -98,7 +98,7 @@ export class Slider extends React.PureComponent<SliderProps, SliderState> {
 
     /**
      * In the case where a slider does not contain slides or the slides are
-     * invalid we will not have a current slide.
+     * not showable we will not have a current slide.
      */
     if (this.currentSlide) {
       /**


### PR DESCRIPTION
Previously if the first slide passed a `shouldShowIf` prop it was ignored. Now we check it in `componentDidMount`. Additionally the back button disabling is based on the first showable slide rather than the slide at position 0. Added a skippable slider example to hammer this point home.