### PR TITLE
reevaluate next/prev slide after lifecycle hooks are complete

### DIFF
--- a/packages/example/src/components/pages/SliderFormWithSkipsInHooks.js
+++ b/packages/example/src/components/pages/SliderFormWithSkipsInHooks.js
@@ -1,0 +1,80 @@
+/* eslint-disable no-alert, react/prefer-stateless-function */
+import React, { Component } from 'react';
+import { Slide, Slider } from '@swan-form/slider';
+import { hot } from 'react-hot-loader';
+
+const onSubmit = values => {
+  alert(JSON.stringify(values));
+  return values;
+};
+const beforeSubmit = values =>
+  Promise.resolve(
+    Object.keys(values).reduce(
+      (acc, key) => ({ ...acc, [key]: typeof values[key] === 'string' ? values[key].toUpperCase() : values[key] }),
+      {},
+    ),
+  );
+
+class SliderFormWithSkipsInHooks extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = { skip: undefined };
+  }
+
+  scrollToTop = () => {
+    if (this.wrapper) {
+      // will probably only work fully in Firefox and Chrome
+      this.wrapper.scrollIntoView({ behavior: 'smooth', block: 'start', inline: 'nearest' });
+    }
+  };
+
+  setRef = el => {
+    this.wrapper = el;
+  };
+
+  render() {
+    const { skip } = this.state;
+
+    return (
+      <div ref={this.setRef}>
+        <Slider afterSlideChange={this.scrollToTop} beforeSubmit={beforeSubmit} onSubmit={onSubmit}>
+          <Slide
+            beforeExit={() => {
+              const self = this;
+              return new Promise(res =>
+                setTimeout(() => {
+                  res(self.setState({ skip: true }));
+                }, 2000),
+              );
+            }}
+          >
+            <div>
+              <h1>First slide sets skip on the component</h1>
+              <p>I hope this works.</p>
+            </div>
+          </Slide>
+          <Slide shouldShowIf={() => !skip}>
+            <div>
+              <h1>You should not see this slide</h1>
+              <p>Because beforeExit sets skip to true.</p>
+            </div>
+          </Slide>
+          <Slide shouldShowIf={() => skip}>
+            <div>
+              <h1>This slide should not be skipped</h1>
+              <p>Because beforeExit sets skip to true.</p>
+            </div>
+          </Slide>
+          <Slide>
+            <div>
+              <h2>Well that&apos;s it I guess.</h2>
+            </div>
+          </Slide>
+        </Slider>
+      </div>
+    );
+  }
+}
+
+export default hot(module)(SliderFormWithSkipsInHooks);

--- a/packages/example/src/routes.js
+++ b/packages/example/src/routes.js
@@ -88,7 +88,7 @@ export const pages = [
   ['/slider-form', 'Slider', SliderForm],
   ['/slider-form-with-skips', 'SliderWithSkips', SliderFormWithSkips],
   ['/slider-form-without-showable-slides', 'SliderWithoutShowableSlides', SliderFormWithoutShowableSlides],
-  ['/slider-form-with-skips-in-hooks', 'AdvancedSliderWithSkips', SliderFormWithSkipsInHooks],
+  ['/slider-form-with-skips-in-hooks', 'SliderFormWithSkipsInHooks', SliderFormWithSkipsInHooks],
   ['/styling', 'Styling', Styling],
   ['/nested', 'Nested', Nested],
   ['/with-redux', 'With Redux', Dummy],

--- a/packages/example/src/routes.js
+++ b/packages/example/src/routes.js
@@ -29,6 +29,11 @@ const SliderFormWithoutShowableSlides = Loader(
   Loading,
 );
 
+const SliderFormWithSkipsInHooks = Loader(
+  () => import(/* webpackChunkName: "sliderFormWithSkipsInHooks" */ './components/pages/SliderFormWithSkipsInHooks'),
+  Loading,
+);
+
 const Formatters = Loader(
   () => import(/* webpackChunkName: "formatters-example" */ './components/pages/Formatters'),
   Loading,
@@ -83,6 +88,7 @@ export const pages = [
   ['/slider-form', 'Slider', SliderForm],
   ['/slider-form-with-skips', 'SliderWithSkips', SliderFormWithSkips],
   ['/slider-form-without-showable-slides', 'SliderWithoutShowableSlides', SliderFormWithoutShowableSlides],
+  ['/slider-form-with-skips-in-hooks', 'AdvancedSliderWithSkips', SliderFormWithSkipsInHooks],
   ['/styling', 'Styling', Styling],
   ['/nested', 'Nested', Nested],
   ['/with-redux', 'With Redux', Dummy],

--- a/packages/slider/src/Slider.tsx
+++ b/packages/slider/src/Slider.tsx
@@ -211,11 +211,8 @@ export class Slider extends React.PureComponent<SliderProps, SliderState> {
       return;
     }
 
-    // Grab the next viable slide index
-    const nextSlideIndex = this.findNext();
-
     // If we are at the end, then handle the end state
-    if (nextSlideIndex >= this.getChildren().length) {
+    if (this.findNext() >= this.getChildren().length) {
       // Call the submit handler on the form
       if (this.form && isFunction(this.form.handleOnSubmit)) {
         execIfFunc(this.form.doSubmit);
@@ -228,12 +225,12 @@ export class Slider extends React.PureComponent<SliderProps, SliderState> {
     const { beforeExit, beforeExitToNext } = this.currentSlide.props;
 
     if (isFunction(beforeExitToNext)) {
-      beforeExitToNext(this.injectSlideProps()).then(() => this.moveTo(nextSlideIndex));
+      beforeExitToNext(this.injectSlideProps()).then(() => this.moveTo(this.findNext()));
       return;
     }
 
     if (isFunction(beforeExit)) {
-      beforeExit(this.injectSlideProps()).then(() => this.moveTo(nextSlideIndex));
+      beforeExit(this.injectSlideProps()).then(() => this.moveTo(this.findNext()));
       return;
     }
 
@@ -245,11 +242,8 @@ export class Slider extends React.PureComponent<SliderProps, SliderState> {
    * Public function to retreat the slide
    */
   prev = () => {
-    // Find the previous slide
-    const prevSlideIndex = this.findPrev();
-
     // If it's the same, do nothing
-    if (prevSlideIndex === this.state.current) {
+    if (this.findPrev() === this.state.current) {
       return;
     }
 
@@ -257,17 +251,17 @@ export class Slider extends React.PureComponent<SliderProps, SliderState> {
     const { beforeExit, beforeExitToPrev } = this.currentSlide.props;
 
     if (isFunction(beforeExitToPrev)) {
-      beforeExitToPrev(this.injectSlideProps()).then(() => this.moveTo(prevSlideIndex));
+      beforeExitToPrev(this.injectSlideProps()).then(() => this.moveTo(this.findPrev()));
       return;
     }
 
     if (isFunction(beforeExit)) {
-      beforeExit(this.injectSlideProps()).then(() => this.moveTo(prevSlideIndex));
+      beforeExit(this.injectSlideProps()).then(() => this.moveTo(this.findPrev()));
       return;
     }
 
     // Just move to the previous slide
-    this.moveTo(prevSlideIndex);
+    this.moveTo(this.findPrev());
   };
 
   /**


### PR DESCRIPTION
The `beforeExit` hook for example can change the output of the `shouldShowIf` function. We need to reevaluate the next/previous slide when moving slides after the hook completes.

## Before
![skips-beforeExit-before-gif](https://user-images.githubusercontent.com/3340414/82363919-8adfd080-99dc-11ea-9783-16202364e3e2.gif)

## After
![skips-beforeExit-after-gif](https://user-images.githubusercontent.com/3340414/82364363-338e3000-99dd-11ea-96e6-efe88efe4bc3.gif)
