### PR TITLE
allow for options in a select field to be disabled

### DIFF
--- a/packages/example/src/components/pages/RegularForm.js
+++ b/packages/example/src/components/pages/RegularForm.js
@@ -45,6 +45,7 @@ class RegularForm extends Component {
       'You should see a console.error message 👇 about an invalid type. It is a test to make sure that invalid types throw an error message. The field will instead be replaced with an HTML comment.',
     );
   }
+
   render() {
     return (
       <div>
@@ -210,7 +211,14 @@ class RegularForm extends Component {
                 name="selectField"
                 type="select"
                 multiple
-                options={['one', 'two', 'three', { label: 'four', value: 'four' }, { OptGroup: ['abc', 'def', 'hij'] }]}
+                options={[
+                  'one',
+                  'two',
+                  'three',
+                  { label: 'four', value: 'four' },
+                  { label: 'five (disabled)', value: 'five', disabled: true },
+                  { OptGroup: ['abc', 'def', 'hij'] },
+                ]}
               />
             </div>
             <br />

--- a/packages/example/src/components/pages/RegularForm.js
+++ b/packages/example/src/components/pages/RegularForm.js
@@ -208,9 +208,23 @@ class RegularForm extends Component {
             </div>
             <div>
               <Field
-                name="selectField"
+                name="multiSelectField"
                 type="select"
                 multiple
+                options={[
+                  'one',
+                  'two',
+                  'three',
+                  { label: 'four', value: 'four' },
+                  { label: 'five (disabled)', value: 'five', disabled: true },
+                  { OptGroup: ['abc', 'def', 'hij'] },
+                ]}
+              />
+            </div>
+            <div>
+              <Field
+                name="selectField"
+                type="select"
                 options={[
                   'one',
                   'two',

--- a/packages/field/src/Field.tsx
+++ b/packages/field/src/Field.tsx
@@ -1,6 +1,8 @@
 /* eslint-disable react/button-has-type */
 import * as React from 'react';
+
 import { classes, hasOwnProperty, isObject, noop, toKey } from '@swan-form/helpers';
+
 import asField, { InjectedProps } from './asField';
 
 export interface FieldProps {
@@ -100,9 +102,9 @@ function renderOption(option: any): React.ReactNode {
   if (isObject(option)) {
     // If it's a label/value object, the render it appropriately
     if (hasOwnProperty(option, 'label') && hasOwnProperty(option, 'value')) {
-      const { label, value } = option;
+      const { label, value, disabled = false } = option;
       return (
-        <option key={value} value={value}>
+        <option key={value} value={value} disabled={disabled}>
           {label}
         </option>
       );


### PR DESCRIPTION
This PR allows for options in a select field to be disabled when using explicit `label` and `value` keys. E.g.

```
<Field
  name="select-field"
  type="select"
  options={[
   { label: 'First Option', value: 1 },
   { label: 'Second Option', value: 2, disabled: true },
   { label: 'Third Option', value: 3 },
  ]}
/>
```